### PR TITLE
refactor: make `readFromWasmActorByAddress` view-only

### DIFF
--- a/src/BucketManager.sol
+++ b/src/BucketManager.sol
@@ -75,23 +75,24 @@ contract BucketManager is IBucketManager {
     }
 
     /// @dev See {IBucketManager-get}.
-    function get(string memory bucket, string memory key) external returns (Value memory) {
+    function get(string memory bucket, string memory key) external view returns (Value memory) {
         return LibBucket.get(bucket, key);
     }
 
     /// @dev See {IBucketManager-query}.
-    function query(string memory bucket) external returns (Query memory) {
+    function query(string memory bucket) external view returns (Query memory) {
         return LibBucket.query(bucket, "", "/", 0, 0);
     }
 
     /// @dev See {IBucketManager-query}.
-    function query(string memory bucket, string memory prefix) external returns (Query memory) {
+    function query(string memory bucket, string memory prefix) external view returns (Query memory) {
         return LibBucket.query(bucket, prefix, "/", 0, 0);
     }
 
     /// @dev See {IBucketManager-query}.
     function query(string memory bucket, string memory prefix, string memory delimiter)
         external
+        view
         returns (Query memory)
     {
         return LibBucket.query(bucket, prefix, delimiter, 0, 0);
@@ -100,6 +101,7 @@ contract BucketManager is IBucketManager {
     /// @dev See {IBucketManager-query}.
     function query(string memory bucket, string memory prefix, string memory delimiter, uint64 offset)
         external
+        view
         returns (Query memory)
     {
         return LibBucket.query(bucket, prefix, delimiter, offset, 0);
@@ -108,6 +110,7 @@ contract BucketManager is IBucketManager {
     /// @dev See {IBucketManager-query}.
     function query(string memory bucket, string memory prefix, string memory delimiter, uint64 offset, uint64 limit)
         external
+        view
         returns (Query memory)
     {
         return LibBucket.query(bucket, prefix, delimiter, offset, limit);

--- a/src/interfaces/IBucketManager.sol
+++ b/src/interfaces/IBucketManager.sol
@@ -70,18 +70,18 @@ interface IBucketManager {
     /// @param bucket The bucket.
     /// @param key The key.
     /// @return value Object's value. See {Value} for more details.
-    function get(string memory bucket, string memory key) external returns (Value memory);
+    function get(string memory bucket, string memory key) external view returns (Value memory);
 
     /// @dev Query the bucket.
     /// @param bucket The bucket.
     /// @return The CBOR encoded query data.
-    function query(string memory bucket) external returns (Query memory);
+    function query(string memory bucket) external view returns (Query memory);
 
     /// @dev Query the bucket.
     /// @param bucket The bucket.
     /// @param prefix The prefix.
     /// @return The CBOR encoded query data.
-    function query(string memory bucket, string memory prefix) external returns (Query memory);
+    function query(string memory bucket, string memory prefix) external view returns (Query memory);
 
     /// @dev Query the bucket.
     /// @param bucket The bucket.
@@ -90,6 +90,7 @@ interface IBucketManager {
     /// @return The CBOR encoded query data.
     function query(string memory bucket, string memory prefix, string memory delimiter)
         external
+        view
         returns (Query memory);
 
     /// @dev Query the bucket.
@@ -100,6 +101,7 @@ interface IBucketManager {
     /// @return All objects matching the query.
     function query(string memory bucket, string memory prefix, string memory delimiter, uint64 offset)
         external
+        view
         returns (Query memory);
 
     /// @dev Query the bucket.
@@ -111,5 +113,6 @@ interface IBucketManager {
     /// @return All objects matching the query.
     function query(string memory bucket, string memory prefix, string memory delimiter, uint64 offset, uint64 limit)
         external
+        view
         returns (Query memory);
 }

--- a/src/util/LibBucket.sol
+++ b/src/util/LibBucket.sol
@@ -256,7 +256,7 @@ library LibBucket {
     /// @param bucket The bucket.
     /// @param key The object key.
     /// @return Object's value. See {Value} for more details.
-    function get(string memory bucket, string memory key) external returns (Value memory) {
+    function get(string memory bucket, string memory key) external view returns (Value memory) {
         bytes memory bucketAddr = bucket.encodeCborActorAddress();
         bytes memory params = key.encodeCborBytes();
         bytes memory data = LibWasm.readFromWasmActorByAddress(bucketAddr, METHOD_GET_OBJECT, params);
@@ -272,6 +272,7 @@ library LibBucket {
     /// @return All objects matching the query.
     function query(string memory bucket, string memory prefix, string memory delimiter, uint64 offset, uint64 limit)
         external
+        view
         returns (Query memory)
     {
         bytes memory bucketAddr = bucket.encodeCborActorAddress();


### PR DESCRIPTION
- Allows bucket methods to be read-only (getting, querying), which impacts downstream clients that use the ABI to determine if a function is for read or write operations (e.g., viem).
- Alters the `readFromWasmActorByAddress` method to follow the workaround that `filecoin-solidity` does [here](https://github.com/filecoin-project/filecoin-solidity/blob/c594feadbcff2be6fb42962b305d7acf67d2dec4/contracts/v0.8/utils/Actor.sol#L142), which is needed due to the `delegatecall` usage under the hood