### PR TITLE
fix: enforce paris evm version

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,7 @@ extra_output = ["storageLayout"]
 gas_reports = ["Hoku"]
 ffi = true
 ast = true
+evm_version = "paris"
 
 [fmt]
 # These are all the `forge fmt` defaults


### PR DESCRIPTION
although this doesnt directly impact anything in `ipc` builds, we might as well keep things consistent and pin the evm version as `paris` since `cancun` wont work when deploying to the subnet. see this PR for details: https://github.com/hokunet/ipc/pull/336