### PR TITLE
refactor: faucet drip updates

### DIFF
--- a/src/token/Faucet.sol
+++ b/src/token/Faucet.sol
@@ -27,7 +27,7 @@ contract Faucet is Ownable {
     mapping(string => uint256) internal _nextRequestAt;
 
     /// @dev Amount of tokens to drip per request
-    uint256 internal _dripAmount = 100;
+    uint256 internal _dripAmount = 18;
 
     /// @dev Initializes the Faucet contract
     /// @dev Sets the contract deployer as the initial owner
@@ -71,7 +71,7 @@ contract Faucet is Ownable {
             revert FaucetEmpty();
         }
         for (uint256 i = 0; i < keysLength; i++) {
-            _nextRequestAt[keys[i]] = block.timestamp + (60 minutes);
+            _nextRequestAt[keys[i]] = block.timestamp + (12 hours);
         }
         recipient.transfer(amount);
     }

--- a/test/Faucet.t.sol
+++ b/test/Faucet.t.sol
@@ -16,8 +16,8 @@ contract FaucetTest is Test {
     Vm.Wallet internal chain;
     address internal owner;
     address internal constant TESTER = address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
-    string[] internal KEYS = ["test1", "test2"];
     uint256 internal constant MINT_AMOUNT = 1000 * 10 ** 18;
+    string[] internal keys = ["test1", "test2"];
 
     function setUp() public virtual {
         chain = vm.createWallet("chain");
@@ -33,7 +33,7 @@ contract FaucetTest is Test {
         assertEq(wallet.addr.balance, 0);
 
         vm.prank(owner);
-        faucet.drip(payable(wallet.addr), KEYS);
+        faucet.drip(payable(wallet.addr), keys);
 
         assertEq(faucet.supply(), MINT_AMOUNT / 2 - faucet.dripAmount());
         assertEq(wallet.addr.balance, faucet.dripAmount());
@@ -41,20 +41,20 @@ contract FaucetTest is Test {
 
     function testDripTransferNoDelayFail() public {
         vm.prank(owner);
-        faucet.drip(payable(wallet.addr), KEYS);
+        faucet.drip(payable(wallet.addr), keys);
 
         vm.expectRevert(TryLater.selector);
         vm.prank(owner);
-        faucet.drip(payable(wallet.addr), KEYS);
+        faucet.drip(payable(wallet.addr), keys);
     }
 
     function testDripTransferDelay() public {
         vm.startPrank(owner);
-        faucet.drip(payable(wallet.addr), KEYS);
+        faucet.drip(payable(wallet.addr), keys);
 
-        vm.warp(block.timestamp + (60 minutes));
+        vm.warp(block.timestamp + (12 hours));
 
-        faucet.drip(payable(wallet.addr), KEYS);
+        faucet.drip(payable(wallet.addr), keys);
         vm.stopPrank();
 
         assertEq(wallet.addr.balance, 2 * faucet.dripAmount());


### PR DESCRIPTION
A couple small changes to lock down calls to `drip` and make rate limiting more flexible:

- Update `drip` to be onlyOwner
- Allow `drip` caller to provide rate limiting lookup key. This allows us to key rate limiting any way we want, using the caller address or caller ip address, for example.
- Make rate limit period 1 hour