### PR TITLE
refactor: don't index `address[] caller` in event

### DIFF
--- a/src/interfaces/ICreditManager.sol
+++ b/src/interfaces/ICreditManager.sol
@@ -9,12 +9,7 @@ import {Account, Balance, CreditApproval, CreditStats} from "../types/BlobTypes.
 interface ICreditManager {
     /// @dev Emitted when an account approves credits.
     event ApproveCredit(
-        address indexed from,
-        address indexed to,
-        address[] indexed caller,
-        uint256 creditLimit,
-        uint256 gasFeeLimit,
-        uint64 ttl
+        address indexed from, address indexed to, address[] caller, uint256 creditLimit, uint256 gasFeeLimit, uint64 ttl
     );
 
     /// @dev Emitted when an account buys credits.


### PR DESCRIPTION
Parsing `address[]` in events is easier if the param isn't indexed. E.g., with viem, you can directly get the `[0x1234...]` address in the event, but if `address[]` is indexed, you have to decode some index hex value like `0x9876...` and then decode the addresses accordingly.