### PR TITLE
feat: handle account approvals to/from

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,13 +385,13 @@ We can get the credit account info for the address at `EVM_ADDRESS` (the variabl
 you could provide any account's EVM public key that exists in the subnet.
 
 ```sh
-cast abi-decode "getAccount(address)((uint64,uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],uint64,uint256))" $(cast call --rpc-url $ETH_RPC_URL $CREDIT "getAccount(address)" $EVM_ADDRESS)
+cast abi-decode "getAccount(address)((uint64,uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],(address,(uint256,uint256,uint64,uint256,uint256))[],uint64,uint256))" $(cast call --rpc-url $ETH_RPC_URL $CREDIT "getAccount(address)" $EVM_ADDRESS)
 ```
 
 This will return the following values:
 
 ```
-(6, 4999999999999999454276000000000000000000 [4.999e39], 504150000000000000000000 [5.041e23], 0x0000000000000000000000000000000000000000, 7200, [(0x90F79bf6EB2c4f870365E785982E1f101E93b906, (12345000000000000000000 [1.234e22], 987654321 [9.876e8], 11722 [1.172e4], 0, 0))], 86400 [8.64e4], 4999999984799342175554 [4.999e21])
+(6, 4999999999999999454276000000000000000000 [4.999e39], 504150000000000000000000 [5.041e23], 0x0000000000000000000000000000000000000000, 7200, [(0x90F79bf6EB2c4f870365E785982E1f101E93b906, (12345000000000000000000 [1.234e22], 987654321 [9.876e8], 11722 [1.172e4], 0, 0))], [], 86400 [8.64e4], 4999999984799342175554 [4.999e21])
 ```
 
 Which maps to the `Account` struct:
@@ -403,7 +403,8 @@ struct Account {
     uint256 creditCommitted; // 504150000000000000000000
     address creditSponsor; // 0x0000000000000000000000000000000000000000 (null)
     uint64 lastDebitEpoch; // 7200
-    Approval[] approvals; // See Approval struct below
+    Approval[] approvalsTo; // See Approval struct below
+    Approval[] approvalsFrom; // [] (empty)
     uint64 maxTtl; // 86400
     uint256 gasAllowance; // 4999999984799342175554
 }
@@ -414,7 +415,7 @@ approvals authorized. We can expand this to be interpreted as the following:
 
 ```solidity
 struct Approval {
-    string to; // 0x90F79bf6EB2c4f870365E785982E1f101E93b906
+    address addr; // 0x90F79bf6EB2c4f870365E785982E1f101E93b906
     CreditApproval approval; // See CreditApproval struct below
 }
 
@@ -489,7 +490,7 @@ struct CreditApproval {
 Fetch the credit balance for the address at `EVM_ADDRESS`:
 
 ```sh
-cast abi-decode "getCreditBalance(address)((uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],uint256))" $(cast call --rpc-url $ETH_RPC_URL $CREDIT "getCreditBalance(address)" $EVM_ADDRESS)
+cast abi-decode "getCreditBalance(address)((uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],(address,(uint256,uint256,uint64,uint256,uint256))[],uint256))" $(cast call --rpc-url $ETH_RPC_URL $CREDIT "getCreditBalance(address)" $EVM_ADDRESS)
 ```
 
 This will return the following values:
@@ -948,7 +949,6 @@ accepts "optional" arguments. All of the method parameters and return types can 
   the string that was chosen during `addBlob`).
 - `overwriteBlob(string,AddBlobParams memory)`: Overwrite a blob from the network, passing the old
   blob hash, and the new blob parameters.
-- `getAccountType(address)`: Get the account's max blob TTL.
 - `getBlob(string)`: Get information about a specific blob at its blake3 hash.
 - `getBlobStatus(address,string,string)`: Get a blob's status, providing its credit sponsor (i.e.,
   the account's `address`, or `address(0)` if null), its blake3 blob hash (the first `string`

--- a/src/types/BlobTypes.sol
+++ b/src/types/BlobTypes.sol
@@ -7,13 +7,8 @@ pragma solidity ^0.8.26;
 /// @param creditCommitted (uint256): Current committed credit in byte-blocks that will be used for debits.
 /// @param creditSponsor (address): Optional default sponsor account address.
 /// @param lastDebitEpoch (uint64): The chain epoch of the last debit.
-/// @param approvals (Approvals[]): Credit approvals to other accounts, keyed by receiver, keyed by caller,
-/// which could be the receiver or a specific contract, like a bucket.
-/// This allows for limiting approvals to interactions from a specific contract.
-/// For example, an approval for Alice might be valid for any contract caller, so long as
-/// the origin is Alice.
-/// An approval for Bob might be valid from only one contract caller, so long as
-/// the origin is Bob.
+/// @param approvalsTo (Approvals[]): Credit approvals to other accounts from this account, keyed by receiver.
+/// @param approvalsFrom (Approvals[]): Credit approvals to this account from other accounts, keyed by sender.
 /// @param maxTtl (uint64): The maximum allowed TTL for actor's blobs.
 struct Account {
     uint64 capacityUsed;
@@ -22,17 +17,18 @@ struct Account {
     address creditSponsor;
     uint64 lastDebitEpoch;
     // Note: this is a nested array that emulates a Rust `HashMap<String, CreditApproval>`
-    Approval[] approvals;
+    Approval[] approvalsTo;
+    Approval[] approvalsFrom;
     uint64 maxTtl;
     uint256 gasAllowance;
 }
 
 /// @dev Credit approval from one account to another.
-/// @param to (address): Optional restriction on caller address, e.g., an object store. Use zero address if
+/// @param addr (address): Optional restriction on caller address, e.g., an object store. Use zero address if
 /// unused, indicating a null value.
 /// @param approval (CreditApproval): The credit approval. See {CreditApproval} for more details.
 struct Approval {
-    address to;
+    address addr;
     CreditApproval approval;
 }
 
@@ -41,20 +37,16 @@ struct Approval {
 /// @param creditCommitted (uint256): Current committed credit in byte-blocks that will be used for debits.
 /// @param creditSponsor (address): Optional default sponsor account address.
 /// @param lastDebitEpoch (uint64): The chain epoch of the last debit.
-/// @param approvals (Approvals[]): Credit approvals to other accounts, keyed by receiver, keyed by caller,
-/// which could be the receiver or a specific contract, like a bucket.
-/// This allows for limiting approvals to interactions from a specific contract.
-/// For example, an approval for Alice might be valid for any contract caller, so long as
-/// the origin is Alice.
-/// An approval for Bob might be valid from only one contract caller, so long as
-/// the origin is Bob.
+/// @param approvalsTo (Approvals[]): Credit approvals to other accounts from this account, keyed by receiver.
+/// @param approvalsFrom (Approvals[]): Credit approvals to this account from other accounts, keyed by sender.
 /// @param gasAllowance (uint256): The amount of gas allowance for the account.
 struct Balance {
     uint256 creditFree;
     uint256 creditCommitted;
     address creditSponsor;
     uint64 lastDebitEpoch;
-    Approval[] approvals;
+    Approval[] approvalsTo;
+    Approval[] approvalsFrom;
     uint256 gasAllowance;
 }
 

--- a/test/LibBlob.t.sol
+++ b/test/LibBlob.t.sol
@@ -45,56 +45,50 @@ contract LibBlobTest is Test {
     function testDecodeAccount() public view {
         // No approvals
         bytes memory data =
-            hex"880652000eb194f8e1ae50e56f45b07f78a0d400004b006dc68533171604000000f6191834a01a000151804b00010f0cf0647ee57f02b9";
+            hex"890052000eb194f8e1ae525fd5dcfab0800000000040f6191068a0a01a000151804b00010f0cf064dd59200000";
         CreditAccount memory account = data.decodeAccount();
-        assertEq(account.capacityUsed, 6);
-        assertEq(account.creditFree, 4999999999999998213053000000000000000000);
-        assertEq(account.creditCommitted, 518400000000000000000000);
+        assertEq(account.capacityUsed, 0);
+        assertEq(account.creditFree, 5000000000000000000000000000000000000000);
+        assertEq(account.creditCommitted, 0);
         assertEq(account.creditSponsor, address(0));
-        assertEq(account.lastDebitEpoch, 6196);
-        assertEq(account.approvals.length, 0);
+        assertEq(account.lastDebitEpoch, 4200);
+        assertEq(account.approvalsTo.length, 0);
+        assertEq(account.approvalsFrom.length, 0);
         assertEq(account.maxTtl, 86400);
-        assertEq(account.gasAllowance, 4999999999594333143737);
+        assertEq(account.gasAllowance, 5000000000000000000000);
 
-        // With approvals to two different accounts, but no set credit, gas fee, or ttl limits
+        // With all fields set: approvals to two different accounts, approvals from one account, and all optionals (set
+        // credit limit, gas fee limit, and ttl)
         data =
-            hex"880652000eb194f8e1ae50e56f45b07f78a0d400004b006dc68533171604000000f6191834a265663031323585f6f6f6404065663031323785f6f6f640401a000151804b00010f0cf0647e8620f2b9";
+            hex"890652000eb61887b895080136932adf5bcc4800004b006dc6853317160400000056040a15d34aaf54267db7d7c367839aaf71a00a2c6a65193b4ea2782c663431306663786a75766c3275657a3633707636646d36627a766c33727561666379327466766264617a7069854c0052b7d2dcc80cd2e400000045003b9aca001949ba4b000f60a131ed58b468000045003b9aca00782c663431306674667376613769326b77366d65326b346c6335626e367a7833616d33626a673436367667376a6985f6f6f64040a1782c663431306663786a75766c3275657a3633707636646d36627a766c33727561666379327466766264617a706985f6f6f64045002faf08001a000151804b00010f6034abfb0e425a07";
         account = data.decodeAccount();
         assertEq(account.capacityUsed, 6);
-        assertEq(account.creditFree, 4999999999999998213053000000000000000000);
+        assertEq(account.creditFree, 5005999999999999352418000000000000000000);
         assertEq(account.creditCommitted, 518400000000000000000000);
-        assertEq(account.creditSponsor, address(0));
-        assertEq(account.lastDebitEpoch, 6196);
-        assertEq(account.approvals.length, 2);
-        // Note: tests will always show this as a masked ID address, but in reality, it's a looked up delegated address
-        // This is because tests don't access the delegated address lookup precompile via the FVM runtime
-        assertEq(account.approvals[0].to, 0xFF0000000000000000000000000000000000007D);
-        assertEq(account.approvals[0].approval.creditLimit, 0);
-        assertEq(account.approvals[0].approval.gasFeeLimit, 0);
-        assertEq(account.approvals[0].approval.expiry, 0);
-        assertEq(account.approvals[0].approval.creditUsed, 0);
-        assertEq(account.approvals[0].approval.gasFeeUsed, 0);
-        // Note: tests will always show this as a masked ID address, but in reality, it's a looked up delegated address
-        assertEq(account.approvals[1].to, 0xff0000000000000000000000000000000000007f);
-        assertEq(account.approvals[1].approval.creditLimit, 0);
-        assertEq(account.approvals[1].approval.gasFeeLimit, 0);
-        assertEq(account.approvals[1].approval.expiry, 0);
-        assertEq(account.approvals[1].approval.creditUsed, 0);
-        assertEq(account.approvals[1].approval.gasFeeUsed, 0);
+        assertEq(account.creditSponsor, 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65);
+        assertEq(account.lastDebitEpoch, 15182);
+        assertEq(account.approvalsTo.length, 2);
+        assertEq(account.approvalsFrom.length, 1);
         assertEq(account.maxTtl, 86400);
-        assertEq(account.gasAllowance, 4999999999592733143737);
-
-        // With approval to one account with set credit, gas fee, and ttl limits
-        data =
-            hex"880652000eb194f8e1ae50e56f45b07f78a0d400004b006dc68533171604000000f6191834a1656630313235854c0052b7d2dcc80cd2e4000000430003e81927844b0005650e85ae5dfb900000401a000151804b00010f0cf0647f152e0ab9";
-        account = data.decodeAccount();
-        // Note: tests will always show this as a masked ID address, but in reality, it's a looked up delegated address
-        assertEq(account.approvals[0].to, 0xFF0000000000000000000000000000000000007D);
-        assertEq(account.approvals[0].approval.creditLimit, 100000000000000000000000000);
-        assertEq(account.approvals[0].approval.gasFeeLimit, 1000);
-        assertEq(account.approvals[0].approval.expiry, 10116);
-        assertEq(account.approvals[0].approval.creditUsed, 25476000000000000000000);
-        assertEq(account.approvals[0].approval.gasFeeUsed, 0);
+        assertEq(account.gasAllowance, 5005999998796482894343);
+        assertEq(account.approvalsTo[0].addr, 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65);
+        assertEq(account.approvalsTo[0].approval.creditLimit, 100000000000000000000000000);
+        assertEq(account.approvalsTo[0].approval.gasFeeLimit, 1000000000);
+        assertEq(account.approvalsTo[0].approval.expiry, 18874);
+        assertEq(account.approvalsTo[0].approval.creditUsed, 72618000000000000000000);
+        assertEq(account.approvalsTo[0].approval.gasFeeUsed, 1000000000);
+        assertEq(account.approvalsTo[1].addr, 0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc);
+        assertEq(account.approvalsTo[1].approval.creditLimit, 0);
+        assertEq(account.approvalsTo[1].approval.gasFeeLimit, 0);
+        assertEq(account.approvalsTo[1].approval.expiry, 0);
+        assertEq(account.approvalsTo[1].approval.creditUsed, 0);
+        assertEq(account.approvalsTo[1].approval.gasFeeUsed, 0);
+        assertEq(account.approvalsFrom[0].addr, 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65);
+        assertEq(account.approvalsFrom[0].approval.creditLimit, 0);
+        assertEq(account.approvalsFrom[0].approval.gasFeeLimit, 0);
+        assertEq(account.approvalsFrom[0].approval.expiry, 0);
+        assertEq(account.approvalsFrom[0].approval.creditUsed, 0);
+        assertEq(account.approvalsFrom[0].approval.gasFeeUsed, 800000000);
     }
 
     function testEncodeApproveCreditParams() public pure {

--- a/test/LibWasm.t.sol
+++ b/test/LibWasm.t.sol
@@ -209,6 +209,12 @@ contract LibWasmTest is Test {
         assertEq(result, hex"024722ebdc6ff1cd1c5e01b1484f4ff4cc551f2f19");
     }
 
+    function testDecodeCborDelegatedAddressStringToAddress() public pure {
+        bytes memory data = bytes("f410fsd3zx5xlfrhyoa3f46czqlq7capjhoighmzagaq");
+        address result = LibWasm.decodeCborDelegatedAddressStringToAddress(data);
+        assertEq(result, 0x90F79bf6EB2c4f870365E785982E1f101E93b906);
+    }
+
     function testDecodeCborActorAddress() public pure {
         bytes memory addr = hex"02770d21925703390a236f68f84ef1d432ca5742c4";
         string memory result = LibWasm.decodeCborActorAddress(addr);

--- a/test/scripts/wrapper_integration_test.sh
+++ b/test/scripts/wrapper_integration_test.sh
@@ -309,7 +309,7 @@ if [ "$output" = "0x" ]; then
     echo "getAccount failed"
     exit 1
 fi
-DECODED_ACCOUNT=$(cast abi-decode "getAccount(address)((uint64,uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],uint64,uint256))" "$output")
+DECODED_ACCOUNT=$(cast abi-decode "getAccount(address)((uint64,uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],(address,(uint256,uint256,uint64,uint256,uint256))[],uint64,uint256))" "$output")
 echo "Account info: $DECODED_ACCOUNT"
 
 # Test getCreditStats
@@ -342,7 +342,7 @@ if [ "$output" = "0x" ]; then
     echo "getCreditBalance failed"
     exit 1
 fi
-DECODED_BALANCE=$(cast abi-decode "getCreditBalance(address)((uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],uint256))" $output)
+DECODED_BALANCE=$(cast abi-decode "getCreditBalance(address)((uint256,uint256,address,uint64,(address,(uint256,uint256,uint64,uint256,uint256))[],(address,(uint256,uint256,uint64,uint256,uint256))[],uint256))" $output)
 echo "Credit balance: $DECODED_BALANCE"
 
 # Test buyCredit


### PR DESCRIPTION
- Alter `Account` and `Balance` to include the fields: `approvalsTo` and `approvalsFrom`.
- Alter the `Approval` struct's address field to be called `addr`—since `to` no longer makes sense due to the feature above.
- Add support for decoding these approvals in `getAccount()` and `getCreditBalance()`.
- New cbor decoding method that takes string `f410f...` values and converts them to hex address values.