### PR TITLE
feat: consistent token symbol `RECALL` (without prefix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,6 @@ execute deployment with the given argument above, and the `--broadcast` flag act
 transaction to the network. Recall that you **must** set `-g 100000` to ensure the gas estimate is
 sufficiently high.
 
-Lastly, if you're deploying the Recall ERC20, the environment will dictate different token symbols:
-
-- Local: prefixes `RECALL` with `l`
-- Testnet: prefixes `RECALL` with `t`
-- Mainnet: uses `RECALL`
-
 Mainnet deployments require the address of the Axelar Interchain Token Service on chain you are
 deploying to, which is handled in the ERC20's `DeployScript` logic.
 
@@ -163,9 +157,9 @@ forge script script/Recall.s.sol --tc DeployScript --sig 'run(string)' local --r
 
 ##### Faucet
 
-Deploy the Faucet contract to the localnet subnet. The second argument is the initial supply of Recall
-tokens, owned by the deployer's account which will be transferred to the faucet contract (e.g., 5000
-with 10\*\*18 decimal units).
+Deploy the Faucet contract to the localnet subnet. The second argument is the initial supply of
+Recall tokens, owned by the deployer's account which will be transferred to the faucet contract
+(e.g., 5000 with 10\*\*18 decimal units).
 
 ```shell
 PRIVATE_KEY=<0x...> forge script script/Faucet.s.sol --tc DeployScript --sig 'run(uint256)' 5000000000000000000000 --rpc-url localnet_subnet --private-key $PRIVATE_KEY --broadcast -g 100000 -vv
@@ -199,8 +193,8 @@ forge script script/BlobManager.s.sol --tc DeployScript --sig 'run()' --rpc-url 
 
 ##### Recall ERC20
 
-Deploy the Recall ERC20 contract to the testnet parent chain. Note the `-g` flag _is_ used here (this
-differs from the localnet setup above since we're deploying to Filecoin Calibration);
+Deploy the Recall ERC20 contract to the testnet parent chain. Note the `-g` flag _is_ used here
+(this differs from the localnet setup above since we're deploying to Filecoin Calibration);
 
 ```shell
 forge script script/Recall.s.sol --tc DeployScript --sig 'run(string)' testnet --rpc-url testnet_parent --private-key $PRIVATE_KEY --broadcast -g 100000 -vv
@@ -208,9 +202,9 @@ forge script script/Recall.s.sol --tc DeployScript --sig 'run(string)' testnet -
 
 ##### Faucet
 
-Deploy the Faucet contract to the testnet subnet. The second argument is the initial supply of Recall
-tokens, owned by the deployer's account which will be transferred to the faucet contract (e.g., 5000
-with 10\*\*18 decimal units).
+Deploy the Faucet contract to the testnet subnet. The second argument is the initial supply of
+Recall tokens, owned by the deployer's account which will be transferred to the faucet contract
+(e.g., 5000 with 10\*\*18 decimal units).
 
 ```shell
 forge script script/Faucet.s.sol --tc DeployScript --sig 'run(uint256)' 5000000000000000000000 --rpc-url testnet_subnet --private-key $PRIVATE_KEY --broadcast -g 100000 -vv

--- a/script/Recall.s.sol
+++ b/script/Recall.s.sol
@@ -22,19 +22,9 @@ contract DeployScript is Script {
     function run(string memory network) public returns (Recall) {
         vm.startBroadcast();
 
-        string memory prefix = "";
-        if (Strings.equal(network, "local")) {
-            prefix = "l";
-        } else if (Strings.equal(network, "testnet")) {
-            prefix = "t";
-        } else if (!Strings.equal(network, "ethereum") && !Strings.equal(network, "filecoin")) {
-            // solhint-disable-next-line custom-errors
-            revert("Unsupported network.");
-        }
-
         bytes32 itsSalt = keccak256("RECALL_SALT");
         proxyAddress = Upgrades.deployUUPSProxy(
-            "Recall.sol", abi.encodeCall(Recall.initialize, (prefix, INTERCHAIN_TOKEN_SERVICE, itsSalt))
+            "Recall.sol", abi.encodeCall(Recall.initialize, (INTERCHAIN_TOKEN_SERVICE, itsSalt))
         );
 
         // Check implementation

--- a/src/token/Recall.sol
+++ b/src/token/Recall.sol
@@ -37,12 +37,10 @@ contract Recall is
     }
 
     /// @dev Initializes the contract with the given environment
-    /// @param prefix The prefix for the symbol
     /// @param its The interchain token service address
     /// @param itsSalt The salt for the interchain token service
-    function initialize(string memory prefix, address its, bytes32 itsSalt) public initializer {
-        string memory symbol = string(abi.encodePacked(prefix, "RECALL"));
-        __ERC20_init("Recall", symbol);
+    function initialize(address its, bytes32 itsSalt) public initializer {
+        __ERC20_init("Recall", "RECALL");
         __AccessControl_init();
         __Pausable_init();
         __UUPSUpgradeable_init();

--- a/test/Recall.t.sol
+++ b/test/Recall.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.26;
 
-import {Options, Upgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 import {Test, Vm} from "forge-std/Test.sol";
 import {console2 as console} from "forge-std/console2.sol";
 


### PR DESCRIPTION
Removes the prefix `l` or `t` from the token symbol so that all ERC20s are `RECALL`.