### PR TITLE
fix: deploy script contract shadowed declaration warning

### DIFF
--- a/script/Recall.s.sol
+++ b/script/Recall.s.sol
@@ -36,9 +36,9 @@ contract DeployScript is Script {
         return recall;
     }
 
-    function setDefaultRoles(address proxy, address admin, address minter, address pauser) public {
+    function setDefaultRoles(address proxyToken, address admin, address minter, address pauser) public {
         vm.startBroadcast();
-        Recall recall = Recall(proxy);
+        Recall recall = Recall(proxyToken);
 
         // Only grant new roles if different from current
         // Grant new roles and revoke old ones if different


### PR DESCRIPTION
When the `ipc` localnet starts there is a warning that reads: 
```
Compiler run successful with warnings:
Warning (2519): This declaration shadows an existing declaration.
  --> script/Recall.s.sol:61:30:
   |
61 |     function setDefaultRoles(address proxy, address admin, address minter, address pauser) public {
   |                              ^^^^^^^^^^^^^
Note: The shadowed declaration is here:
  --> script/Recall.s.sol:18:5:
   |
18 |     function proxy() public view returns (address) {
   |     ^ (Relevant source part starts here and spans across multiple lines).
```

This is because the contract has a method named `proxy` so the argument shadows the method and makes it unreachable inside the `setDefaultRoles` method.

It's not a big problem, but it would be nice to eliminate the warning log during the localnet startup.