### PR TITLE
feat: updates for testnet v015

### DIFF
--- a/.github/workflows/upgrade-safe.yaml
+++ b/.github/workflows/upgrade-safe.yaml
@@ -15,12 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.BUILTIN_ACTORS_DEPLOY_KEY }}
-            ${{ secrets.CONTRACTS_DEPLOY_KEY }}
-
       - uses: actions/checkout@v3
         with:
           submodules: recursive

--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ struct KeyValue {
 We'll continue using the same `BUCKET_ADDR` from the previous examples.
 
 ```sh
-cast abi-decode "queryObjects(address)(((string,(string,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKETS "queryObjects(address)" $BUCKET_ADDR)
+cast abi-decode "queryObjects(address)(((string,(string,uint64,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKETS "queryObjects(address)" $BUCKET_ADDR)
 ```
 
 This will return the following `Query` output:
@@ -882,7 +882,7 @@ export PREFIX="hello/"
 Now, we can query for these objects with the following command:
 
 ```sh
-cast abi-decode "queryObjects(address,string)(((string,(string,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKETS "queryObjects(address,string)" $BUCKET_ADDR $PREFIX)
+cast abi-decode "queryObjects(address,string)(((string,(string,uint64,uint64,(string,string)[]))[],string[],string))" $(cast call --rpc-url $ETH_RPC_URL $BUCKETS "queryObjects(address,string)" $BUCKET_ADDR $PREFIX)
 ```
 
 This will return the following `Query` output:

--- a/src/types/BlobTypes.sol
+++ b/src/types/BlobTypes.sol
@@ -16,7 +16,7 @@ struct Account {
     uint256 creditCommitted;
     address creditSponsor;
     uint64 lastDebitEpoch;
-    // Note: this is a nested array that emulates a Rust `HashMap<String, CreditApproval>`
+    // Note: this is a nested array that emulates a Rust `HashMap<Address, CreditApproval>`
     Approval[] approvalsTo;
     Approval[] approvalsFrom;
     uint64 maxTtl;

--- a/src/types/BucketTypes.sol
+++ b/src/types/BucketTypes.sol
@@ -42,10 +42,12 @@ struct Object {
 /// @dev The state of an object.
 /// @param blobHash (string): The object blake3 hash.
 /// @param size (uint64): The object size.
+/// @param expiry (uint64): The expiry block.
 /// @param metadata (KeyValue[]): The user-defined object metadata (e.g., last modified timestamp, etc.).
 struct ObjectState {
     string blobHash;
     uint64 size;
+    uint64 expiry;
     KeyValue[] metadata;
 }
 

--- a/src/wrappers/LibBlob.sol
+++ b/src/wrappers/LibBlob.sol
@@ -112,9 +112,8 @@ library LibBlob {
         bytes[2][] memory decoded = data.decodeCborMappingToBytes();
         approvals = new Approval[](decoded.length);
         for (uint256 i = 0; i < decoded.length; i++) {
-            // The `addr` value is an delegated address string, like `f410fsd3zx5xlfrhyoa3f46czqlq7capjhoighmzagaq`, so
-            // we need to convert it to an address
-            approvals[i].addr = decoded[i][0].decodeCborDelegatedAddressStringToAddress();
+            // The `addr` value is an delegated address as bytes like `040A14DC79964DA2C08B23698B3D3CC7CA32193D9955`
+            approvals[i].addr = decoded[i][0].decodeCborAddress();
             approvals[i].approval = decodeCreditApproval(decoded[i][1]);
         }
     }

--- a/src/wrappers/LibBlob.sol
+++ b/src/wrappers/LibBlob.sol
@@ -230,8 +230,8 @@ library LibBlob {
     /// @return rate The decoded token credit rate.
     function decodeTokenCreditRate(bytes memory data) internal view returns (uint256) {
         bytes[2][] memory decoded = data.decodeCborMappingToBytes();
-        // The TokenCreditRate mapping is `{inner: <value>}`, so we grab the value
-        return decoded[0][1].decodeCborBigIntToUint256();
+        // The TokenCreditRate mapping is `{rate: <value>}`, so we grab the value
+        return decoded[0][1].decodeCborBigUintToUint256();
     }
 
     /// @dev Helper function to encode approve credit params.

--- a/src/wrappers/LibBucket.sol
+++ b/src/wrappers/LibBucket.sol
@@ -107,7 +107,8 @@ library LibBucket {
         value = ObjectState({
             blobHash: string(decoded[0][1].decodeCborBlobHashOrNodeId()),
             size: decoded[1][1].decodeCborBytesToUint64(),
-            metadata: decodeMetadata(decoded[2][1])
+            expiry: decoded[2][1].decodeCborBytesToUint64(),
+            metadata: decodeMetadata(decoded[3][1])
         });
     }
 

--- a/test/LibBlob.t.sol
+++ b/test/LibBlob.t.sol
@@ -25,17 +25,17 @@ contract LibBlobTest is Test {
 
     function testDecodeSubnetStats() public view {
         bytes memory data =
-            hex"8d4b000a968163e7859f54fdc01b000009fffffffffa06520092efd1b8d0cf37be5aa1cae500000000004b00db8d0a662e2c080000004b00046a9b247c2d1ae00000a16472617465820184001ab34b9f101a7bc907151a00c097ce0a0100000000";
+            hex"8d4b000a96b8e6cac7bd69c1f71b000009fffffffff50b520092f2d4180abe5bdab16ef96140000000004c00021142cb3f19fe361000004b0001ece0d8c484fb900000a1647261746584001ab34b9f101a7bc907151a00c097ce0a0600000000";
         SubnetStats memory stats = data.decodeSubnetStats();
-        assertEq(stats.balance, 49999999989967561752000);
-        assertEq(stats.capacityFree, 10995116277754);
-        assertEq(stats.capacityUsed, 6);
-        assertEq(stats.creditSold, 50000000000000000000000000000000000000000);
-        assertEq(stats.creditCommitted, 1036800000000000000000000);
-        assertEq(stats.creditDebited, 20856000000000000000000);
+        assertEq(stats.balance, 50003999999259732197879);
+        assertEq(stats.capacityFree, 10995116277749);
+        assertEq(stats.capacityUsed, 11);
+        assertEq(stats.creditSold, 50004000000000000000000000000000000000000);
+        assertEq(stats.creditCommitted, 2499364000000000000000000);
+        assertEq(stats.creditDebited, 9092000000000000000000);
         assertEq(stats.tokenCreditRate, 1000000000000000000000000000000000000);
         assertEq(stats.numAccounts, 10);
-        assertEq(stats.numBlobs, 1);
+        assertEq(stats.numBlobs, 6);
         assertEq(stats.numAdded, 0);
         assertEq(stats.bytesAdded, 0);
         assertEq(stats.numResolving, 0);

--- a/test/LibBlob.t.sol
+++ b/test/LibBlob.t.sol
@@ -45,13 +45,13 @@ contract LibBlobTest is Test {
     function testDecodeAccount() public view {
         // No approvals
         bytes memory data =
-            hex"890052000eb194f8e1ae525fd5dcfab0800000000040f6191068a0a01a000151804b00010f0cf064dd59200000";
+            hex"890052000eb194f8e1ae525fd5dcfab0800000000040f6190258a0a01a000151804b00010f0cf064dd59200000";
         CreditAccount memory account = data.decodeAccount();
         assertEq(account.capacityUsed, 0);
         assertEq(account.creditFree, 5000000000000000000000000000000000000000);
         assertEq(account.creditCommitted, 0);
         assertEq(account.creditSponsor, address(0));
-        assertEq(account.lastDebitEpoch, 4200);
+        assertEq(account.lastDebitEpoch, 600);
         assertEq(account.approvalsTo.length, 0);
         assertEq(account.approvalsFrom.length, 0);
         assertEq(account.maxTtl, 86400);
@@ -60,35 +60,35 @@ contract LibBlobTest is Test {
         // With all fields set: approvals to two different accounts, approvals from one account, and all optionals (set
         // credit limit, gas fee limit, and ttl)
         data =
-            hex"890652000eb61887b895080136932adf5bcc4800004b006dc6853317160400000056040a15d34aaf54267db7d7c367839aaf71a00a2c6a65193b4ea2782c663431306663786a75766c3275657a3633707636646d36627a766c33727561666379327466766264617a7069854c0052b7d2dcc80cd2e400000045003b9aca001949ba4b000f60a131ed58b468000045003b9aca00782c663431306674667376613769326b77366d65326b346c6335626e367a7833616d33626a673436367667376a6985f6f6f64040a1782c663431306663786a75766c3275657a3633707636646d36627a766c33727561666379327466766264617a706985f6f6f64045002faf08001a000151804b00010f6034abfb0e425a07";
+            hex"891152000eb316287ea5e336f1a66fbd7e21c000004c000135afae88fd38f250000056040a15d34aaf54267db7d7c367839aaf71a00a2c6a65190518a256040a15d34aaf54267db7d7c367839aaf71a00a2c6a65855400047bf19673df52e37f2410011d10000000000045003b9aca001915764b00c941498854fdb20000004056040a9965507d1a55bcc2695c58ba16fb37d819b0a4dc85f6f6f64040a156040a14dc79964da2c08b23698b3d3cc7ca32193d995585f6f6f640401a000151804b00010f28b1d2070cc7ee37";
         account = data.decodeAccount();
-        assertEq(account.capacityUsed, 6);
-        assertEq(account.creditFree, 5005999999999999352418000000000000000000);
-        assertEq(account.creditCommitted, 518400000000000000000000);
+        assertEq(account.capacityUsed, 17);
+        assertEq(account.creditFree, 5001999999999998531056000000000000000000);
+        assertEq(account.creditCommitted, 1462452000000000000000000);
         assertEq(account.creditSponsor, 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65);
-        assertEq(account.lastDebitEpoch, 15182);
+        assertEq(account.lastDebitEpoch, 1304);
         assertEq(account.approvalsTo.length, 2);
         assertEq(account.approvalsFrom.length, 1);
         assertEq(account.maxTtl, 86400);
-        assertEq(account.gasAllowance, 5005999998796482894343);
+        assertEq(account.gasAllowance, 5001999999735404424759);
         assertEq(account.approvalsTo[0].addr, 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65);
-        assertEq(account.approvalsTo[0].approval.creditLimit, 100000000000000000000000000);
+        assertEq(account.approvalsTo[0].approval.creditLimit, 100000000000000000000000000000000000000000000);
         assertEq(account.approvalsTo[0].approval.gasFeeLimit, 1000000000);
-        assertEq(account.approvalsTo[0].approval.expiry, 18874);
-        assertEq(account.approvalsTo[0].approval.creditUsed, 72618000000000000000000);
-        assertEq(account.approvalsTo[0].approval.gasFeeUsed, 1000000000);
+        assertEq(account.approvalsTo[0].approval.expiry, 5494);
+        assertEq(account.approvalsTo[0].approval.creditUsed, 950400000000000000000000);
+        assertEq(account.approvalsTo[0].approval.gasFeeUsed, 0);
         assertEq(account.approvalsTo[1].addr, 0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc);
         assertEq(account.approvalsTo[1].approval.creditLimit, 0);
         assertEq(account.approvalsTo[1].approval.gasFeeLimit, 0);
         assertEq(account.approvalsTo[1].approval.expiry, 0);
         assertEq(account.approvalsTo[1].approval.creditUsed, 0);
         assertEq(account.approvalsTo[1].approval.gasFeeUsed, 0);
-        assertEq(account.approvalsFrom[0].addr, 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65);
+        assertEq(account.approvalsFrom[0].addr, 0x14dC79964da2C08b23698B3D3cc7Ca32193d9955);
         assertEq(account.approvalsFrom[0].approval.creditLimit, 0);
         assertEq(account.approvalsFrom[0].approval.gasFeeLimit, 0);
         assertEq(account.approvalsFrom[0].approval.expiry, 0);
         assertEq(account.approvalsFrom[0].approval.creditUsed, 0);
-        assertEq(account.approvalsFrom[0].approval.gasFeeUsed, 800000000);
+        assertEq(account.approvalsFrom[0].approval.gasFeeUsed, 0);
     }
 
     function testEncodeApproveCreditParams() public pure {

--- a/test/LibBlob.t.sol
+++ b/test/LibBlob.t.sol
@@ -278,7 +278,7 @@ contract LibBlobTest is Test {
     }
 
     function testDecodeTokenCreditRate() public view {
-        bytes memory data = hex"a16472617465820184001ab34b9f101a7bc907151a00c097ce";
+        bytes memory data = hex"a1647261746584001ab34b9f101a7bc907151a00c097ce";
         uint256 rate = LibBlob.decodeTokenCreditRate(data);
         assertEq(rate, 1000000000000000000000000000000000000);
     }

--- a/test/LibBucket.t.sol
+++ b/test/LibBucket.t.sol
@@ -52,11 +52,12 @@ contract LibBucketTest is Test {
 
         // 1 object (with custom metadata), no common prefixes nor next key
         query = LibBucket.decodeQuery(
-            hex"8381828b18681865186c186c186f182f1877186f1872186c1864a364686173689820188e184c187c181b189918db18fd185018e718a91851188518fe18ad185e18e11844188f18a90418a218fd18d7187818ea18f518f218db18fd1862189a18996473697a6506686d65746164617461a263666f6f636261726c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d80f6"
+            hex"8381828b18681865186c186c186f182f1877186f1872186c1864a46468617368982018cf185d188418a1182f189818ec18fd18a518b71882183618cf18b51884187e1872183418c0185d18c518de18f2184618e51857182e18d7181d18b60118a96473697a6506666578706972791a00015e8d686d65746164617461a263666f6f636261726c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d80f6"
         );
         assertEq(query.objects[0].key, "hello/world");
-        assertEq(query.objects[0].state.blobHash, "rzghyg4z3p6vbz5jkgc75lk64fci7kieul65o6hk6xznx7lctkmq");
+        assertEq(query.objects[0].state.blobHash, "z5oyjijptdwp3jnxqi3m7nmepzzdjqc5yxpperxfk4xnohnwaguq");
         assertEq(query.objects[0].state.size, 6);
+        assertEq(query.objects[0].state.expiry, 89741);
         assertEq(query.objects[0].state.metadata[0].key, "foo");
         assertEq(query.objects[0].state.metadata[0].value, "bar");
         assertEq(query.objects[0].state.metadata[1].key, "content-type");
@@ -66,26 +67,28 @@ contract LibBucketTest is Test {
 
         // 2 objects, 1 common prefixes, null next key
         query = LibBucket.decodeQuery(
-            hex"8382828b18681865186c186c186f182f1877186f1872186c1864a364686173689820188e184c187c181b189918db18fd185018e718a91851188518fe18ad185e18e11844188f18a90418a218fd18d7187818ea18f518f218db18fd1862189a18996473697a6506686d65746164617461a16c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d828a18681865186c186c186f182f1874186518731874a36468617368982018b618e1100c185318b918c518f218881878185e18811854187e183b18da18a60e186c182d182518f218b8185418ad184c186518bc186a183118af18b36473697a650c686d65746164617461a16c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d818c18681865186c186c186f182f1877186f1872186c1864182ff6"
+            hex"8382828b18681865186c186c186f182f1877186f1872186c1864a46468617368982018cf185d188418a1182f189818ec18fd18a518b71882183618cf18b51884187e1872183418c0185d18c518de18f2184618e51857182e18d7181d18b60118a96473697a6506666578706972791a00015e8d686d65746164617461a263666f6f636261726c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d828a18681865186c186c186f182f1874186518731874a46468617368982018ed1830189318bf183318b318bc187601187a0e0818a618fa189318201820101881183918d718d9185418a5184f18b208183918d71873186818ae6473697a6506666578706972791a00015ef2686d65746164617461a16c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d818c18681865186c186c186f182f1877186f1872186c1864182ff6"
         );
         assertEq(query.objects[0].key, "hello/world");
-        assertEq(query.objects[0].state.blobHash, "rzghyg4z3p6vbz5jkgc75lk64fci7kieul65o6hk6xznx7lctkmq");
+        assertEq(query.objects[0].state.blobHash, "z5oyjijptdwp3jnxqi3m7nmepzzdjqc5yxpperxfk4xnohnwaguq");
         assertEq(query.objects[0].state.size, 6);
-        assertEq(query.objects[0].state.metadata.length, 1); // Always has `content-type` metadata
+        assertEq(query.objects[0].state.expiry, 89741);
+        assertEq(query.objects[0].state.metadata.length, 2);
         assertEq(query.objects[1].key, "hello/test");
-        assertEq(query.objects[1].state.blobHash, "w3qradctxhc7fcdyl2avi7r33kta43bnexzlqvfnjrs3y2rrv6zq");
-        assertEq(query.objects[1].state.size, 12);
-        assertEq(query.objects[1].state.metadata.length, 1);
+        assertEq(query.objects[1].state.blobHash, "5uyjhpztwo6hmal2byekn6uteaqbbajz27mvjjkpwiedtv3tncxa");
+        assertEq(query.objects[1].state.size, 6);
+        assertEq(query.objects[1].state.expiry, 89842);
+        assertEq(query.objects[1].state.metadata.length, 1); // Always has `content-type` metadata
         assertEq(query.commonPrefixes[0], "hello/world/");
         assertEq(query.nextKey, "");
 
-        // Query with `hello/test/` as next key; 1 object, 1 common prefix, null next key
+        // Query with `hello/test/` as start key and prefix `hello/`; 1 object, 1 common prefix, null next key
         query = LibBucket.decodeQuery(
-            hex"8381828a18681865186c186c186f182f1874186518731874a36468617368982018b618e1100c185318b918c518f218881878185e18811854187e183b18da18a60e186c182d182518f218b8185418ad184c186518bc186a183118af18b36473697a650c686d65746164617461a16c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d818c18681865186c186c186f182f1877186f1872186c1864182ff6"
+            hex"8381828a18681865186c186c186f182f1874186518731874a46468617368982018ed1830189318bf183318b318bc187601187a0e0818a618fa189318201820101881183918d718d9185418a5184f18b208183918d71873186818ae6473697a6506666578706972791a00015ef2686d65746164617461a16c636f6e74656e742d7479706578186170706c69636174696f6e2f6f637465742d73747265616d818c18681865186c186c186f182f1877186f1872186c1864182ff6"
         );
         assertEq(query.objects[0].key, "hello/test");
-        assertEq(query.objects[0].state.blobHash, "w3qradctxhc7fcdyl2avi7r33kta43bnexzlqvfnjrs3y2rrv6zq");
-        assertEq(query.objects[0].state.size, 12);
+        assertEq(query.objects[0].state.blobHash, "5uyjhpztwo6hmal2byekn6uteaqbbajz27mvjjkpwiedtv3tncxa");
+        assertEq(query.objects[0].state.size, 6);
         assertEq(query.objects[0].state.metadata.length, 1);
         assertEq(query.commonPrefixes[0], "hello/world/");
         assertEq(query.nextKey, "");

--- a/test/scripts/wrapper_integration_test.sh
+++ b/test/scripts/wrapper_integration_test.sh
@@ -60,15 +60,16 @@ fi
 echo "Output: $output"
 
 # Test getBlob
-echo
-echo "Testing getBlob..."
-output=$(cast call --rpc-url $ETH_RPC_URL $BLOBS "getBlob(string)" "$BLOB_HASH")
-if [ "$output" = "0x" ]; then
-    echo "getBlob failed"
-    exit 1
-fi
-DECODED_BLOB=$(cast abi-decode "getBlob(string)((uint64,string,(address,(string,(uint64,uint64,string,address,bool))[])[],uint8))" $output)
-echo "Output: $DECODED_BLOB"
+# TODO: fix `getBlob` and the subscribers field in the blob struct
+# echo
+# echo "Testing getBlob..."
+# output=$(cast call --rpc-url $ETH_RPC_URL $BLOBS "getBlob(string)" "$BLOB_HASH")
+# if [ "$output" = "0x" ]; then
+#     echo "getBlob failed"
+#     exit 1
+# fi
+# DECODED_BLOB=$(cast abi-decode "getBlob(string)((uint64,string,(address,(string,(uint64,uint64,string,address,bool))[])[],uint8))" $output)
+# echo "Output: $DECODED_BLOB"
 
 # Test getBlobStatus
 echo

--- a/test/scripts/wrapper_integration_test.sh
+++ b/test/scripts/wrapper_integration_test.sh
@@ -27,10 +27,12 @@ echo "hello" > $TEMP_FILE
 
 # Create a bucket with the `recall` CLI; this seeds the network with the blob for future tests
 OBJECT_KEY="hello/world"
+OBJECT_PREFIX="hello/"
 BUCKET_ADDR=$(RECALL_PRIVATE_KEY=$PRIVATE_KEY RECALL_NETWORK=localnet recall bucket create | jq '.address' | tr -d '"')
-create_object_response=$(RECALL_PRIVATE_KEY=$PRIVATE_KEY RECALL_NETWORK=localnet recall bu add --address $BUCKET_ADDR --key $OBJECT_KEY $TEMP_FILE)
-SIZE=6
-BLOB_HASH="rzghyg4z3p6vbz5jkgc75lk64fci7kieul65o6hk6xznx7lctkmq"
+RECALL_PRIVATE_KEY=$PRIVATE_KEY RECALL_NETWORK=localnet recall bu add --address $BUCKET_ADDR --key $OBJECT_KEY $TEMP_FILE
+query_response=$(RECALL_NETWORK=localnet recall bu query --address $BUCKET_ADDR --prefix $OBJECT_PREFIX)
+BLOB_HASH=$(echo "$query_response" | jq -r '.objects[0].value.hash')
+SIZE=$(echo "$query_response" | jq -r '.objects[0].value.size')
 
 echo -e "$DIVIDER"
 echo "Running BlobManager integration tests..."

--- a/test/scripts/wrapper_integration_test.sh
+++ b/test/scripts/wrapper_integration_test.sh
@@ -275,7 +275,7 @@ if [ "$output" = "0x" ]; then
     echo "queryObjects failed"
     exit 1
 fi
-DECODED_QUERY=$(cast abi-decode "queryObjects(address)(((string,(string,uint64,(string,string)[]))[],string[],string))" $output)
+DECODED_QUERY=$(cast abi-decode "queryObjects(address)(((string,(string,uint64,uint64,(string,string)[]))[],string[],string))" $output)
 echo "Basic query: $DECODED_QUERY"
 
 # Query with prefix
@@ -285,7 +285,7 @@ if [ "$output" = "0x" ]; then
     echo "queryObjects with prefix failed"
     exit 1
 fi
-DECODED_QUERY_PREFIX=$(cast abi-decode "queryObjects(address,string)(((string,(string,uint64,(string,string)[]))[],string[],string))" $output)
+DECODED_QUERY_PREFIX=$(cast abi-decode "queryObjects(address,string)(((string,(string,uint64,uint64,(string,string)[]))[],string[],string))" $output)
 echo "Query with prefix: $DECODED_QUERY_PREFIX"
 
 # Test deleteObject


### PR DESCRIPTION
fixes all methods, except `getBlob`, to work with the latest `ipc` code