### PR TITLE
fix: update rewarder implementation

### DIFF
--- a/script/ValidatorRewarder.s.sol
+++ b/script/ValidatorRewarder.s.sol
@@ -22,7 +22,7 @@ contract DeployScript is Script {
     function run(address recallToken) public returns (ValidatorRewarder) {
         vm.startBroadcast();
         proxyAddress = Upgrades.deployUUPSProxy(
-            "ValidatorRewarder.sol", abi.encodeCall(ValidatorRewarder.initialize, (recallToken))
+            "ValidatorRewarder.sol:ValidatorRewarder", abi.encodeCall(ValidatorRewarder.initialize, (recallToken))
         );
         vm.stopBroadcast();
 
@@ -52,9 +52,9 @@ contract UpgradeRewarderProxyScript is Script {
 
         // Upgrade proxy to new implementation
         Options memory opts;
-        opts.referenceContract = "ValidatorRewarder.sol";
+        opts.referenceContract = "ValidatorRewarder.sol:ValidatorRewarder";
         vm.startBroadcast(deployerPrivateKey);
-        Upgrades.upgradeProxy(proxy, "ValidatorRewarder.sol", "", opts);
+        Upgrades.upgradeProxy(proxy, "ValidatorRewarder.sol:ValidatorRewarder", "", opts);
         vm.stopBroadcast();
 
         // Check new implementation

--- a/src/token/ValidatorRewarder.sol
+++ b/src/token/ValidatorRewarder.sol
@@ -13,6 +13,8 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/contracts/pro
 
 import {UD60x18, ud} from "@prb/math/UD60x18.sol";
 
+import {console2} from "forge-std/console2.sol";
+
 /// @title ValidatorRewarder
 /// @notice This contract is responsible for distributing rewards to validators.
 /// @dev The rewarder is responsible for distributing the inflation to the validators.
@@ -136,6 +138,7 @@ contract ValidatorRewarder is IValidatorRewarder, UUPSUpgradeable, OwnableUpgrad
 
         // Mint the validator's share
         token.mint(data.validator, validatorShare);
+        console2.log("====>>> NEW REWARDER CALLED!!!");
         emit RewardsClaimed(claimedCheckpointHeight, data.validator, validatorShare);
     }
 
@@ -181,7 +184,14 @@ contract ValidatorRewarder is IValidatorRewarder, UUPSUpgradeable, OwnableUpgrad
     /// @param claimedCheckpointHeight The height on which the checkpoint was submitted
     /// @return The number of blocks in the checkpoint
     function numBlocksInCheckpoint(uint64 claimedCheckpointHeight) internal view returns (uint64) {
-        address subnetActor = subnet.getAddress();
+        // TODO: This is subnet gateway address
+        // We need parent gateway address
+        SubnetID memory parentSubnet = subnet.getParentSubnet();
+        console2.log("====>>>> PARENT SUBNET");
+        console2.log(parentSubnet.root);
+        address subnetActor = parentSubnet.getAddress();
+        console2.log("====>>>> SUBNET ACTOR");
+        console2.log(subnetActor);
         (bool exists, BottomUpCheckpoint memory checkpoint) =
             ISubnetActorGetter(subnetActor).bottomUpCheckpointAtEpoch(claimedCheckpointHeight);
         if (!exists) {

--- a/src/token/ValidatorRewarder.sol
+++ b/src/token/ValidatorRewarder.sol
@@ -209,7 +209,7 @@ contract ValidatorRewarder is IValidatorRewarder, UUPSUpgradeable, OwnableUpgrad
 }
 
 interface ISubnetActorGetter {
-    function bottomUpCheckpointAtEpoch(uint64 epoch)
+    function bottomUpCheckpointAtEpoch(uint256 epoch)
         external
         view
         returns (bool exists, BottomUpCheckpoint memory checkpoint);

--- a/src/token/ValidatorRewarder.sol
+++ b/src/token/ValidatorRewarder.sol
@@ -186,11 +186,8 @@ contract ValidatorRewarder is IValidatorRewarder, UUPSUpgradeable, OwnableUpgrad
     function numBlocksInCheckpoint(uint64 claimedCheckpointHeight) internal view returns (uint64) {
         // TODO: This is subnet gateway address
         // We need parent gateway address
-        SubnetID memory parentSubnet = subnet.getParentSubnet();
-        console2.log("====>>>> PARENT SUBNET");
-        console2.log(parentSubnet.root);
-        address subnetActor = parentSubnet.getAddress();
-        console2.log("====>>>> SUBNET ACTOR");
+        address subnetActor = subnet.getAddress();
+        console2.log("====>>> SUBNET ACTOR");
         console2.log(subnetActor);
         (bool exists, BottomUpCheckpoint memory checkpoint) =
             ISubnetActorGetter(subnetActor).bottomUpCheckpointAtEpoch(claimedCheckpointHeight);

--- a/src/types/CommonTypes.sol
+++ b/src/types/CommonTypes.sol
@@ -48,3 +48,87 @@ library Consensus {
         uint64 blocksCommitted;
     }
 }
+
+/// @notice A bottom-up checkpoint type.
+struct BottomUpCheckpoint {
+    /// @dev Child subnet ID, for replay protection from other subnets where the exact same validators operate.
+    /// Alternatively it can be appended to the hash before signing, similar to how we use the chain ID.
+    SubnetID subnetID;
+    /// @dev The height of the child subnet at which this checkpoint was cut.
+    /// Has to follow the previous checkpoint by checkpoint period.
+    uint256 blockHeight;
+    /// @dev The hash of the block.
+    bytes32 blockHash;
+    /// @dev The number of the membership (validator set) which is going to sign the next checkpoint.
+    /// This one expected to be signed by the validators from the membership reported in the previous checkpoint.
+    /// 0 could mean "no change".
+    uint64 nextConfigurationNumber;
+    /// @dev Batch of messages to execute.
+    IpcEnvelope[] msgs;
+    /// @dev The activity rollup from child subnet to parent subnet.
+    CompressedActivityRollup activity;
+}
+
+// Compressed representation of the activity summary that can be embedded in checkpoints to propagate up the hierarchy.
+struct CompressedActivityRollup {
+    CompressedSummary consensus;
+}
+
+// Aggregated stats for consensus-level activity.
+struct AggregatedStats {
+    /// The total number of unique validators that have mined within this period.
+    uint64 totalActiveValidators;
+    /// The total number of blocks committed by all validators during this period.
+    uint64 totalNumBlocksCommitted;
+}
+
+// The compresed representation of the activity summary for consensus-level activity suitable for embedding in a
+// checkpoint.
+struct CompressedSummary {
+    AggregatedStats stats;
+    /// The commitment for the validator details, so that we don't have to transmit them in full.
+    bytes32 dataRootCommitment;
+}
+
+/// @notice Type of cross-net messages currently supported
+enum IpcMsgKind {
+    /// @dev for cross-net messages that move native token, i.e. fund/release.
+    /// and in the future multi-level token transactions.
+    Transfer,
+    /// @dev general-purpose cross-net transaction that call smart contracts.
+    Call,
+    /// @dev receipt from the execution of cross-net messages
+    Result
+}
+
+/// @notice An IPC address type.
+struct IPCAddress {
+    SubnetID subnetId;
+    FvmAddress rawAddress;
+}
+
+/// @notice Envelope used to propagate IPC cross-net messages
+struct IpcEnvelope {
+    /// @dev type of message being propagated.
+    IpcMsgKind kind;
+    /// @dev outgoing nonce for the envelope.
+    /// This nonce is set by the gateway when committing the message for propagation.
+    /// This nonce is changed on each network when the message is propagated,
+    /// so it is unique for each network and prevents replay attacks.
+    uint64 localNonce;
+    /// @dev original nonce of the message from the source network.
+    /// It is set once at the source network and remains unchanged during propagation.
+    /// It is used to generate a unique tracing ID across networks, which is useful for debugging and auditing purposes.
+    uint64 originalNonce;
+    /// @dev Value being sent in the message.
+    uint256 value;
+    /// @dev destination of the message
+    /// It makes sense to extract from the encoded message
+    /// all shared fields required by all message, so they
+    /// can be inspected without having to decode the message.
+    IPCAddress to;
+    /// @dev address sending the message
+    IPCAddress from;
+    /// @dev abi.encoded message
+    bytes message;
+}

--- a/test/ValidatorRewarder.t.sol
+++ b/test/ValidatorRewarder.t.sol
@@ -13,13 +13,13 @@ import {Test} from "forge-std/Test.sol";
 
 // Mock implementation of the ISubnetActorGetter interface for testing
 contract MockSubnetActor is ISubnetActorGetter {
-    mapping(uint64 => BottomUpCheckpoint) internal checkpoints;
+    mapping(uint256 => BottomUpCheckpoint) internal checkpoints;
 
-    function setCheckpoint(uint64 epoch, uint64 blocksCommitted) external {
+    function setCheckpoint(uint256 epoch, uint64 blocksCommitted) external {
         checkpoints[epoch].activity.consensus.stats.totalNumBlocksCommitted = blocksCommitted;
     }
 
-    function bottomUpCheckpointAtEpoch(uint64 epoch)
+    function bottomUpCheckpointAtEpoch(uint256 epoch)
         external
         view
         override

--- a/test/ValidatorRewarder.t.sol
+++ b/test/ValidatorRewarder.t.sol
@@ -10,7 +10,6 @@ import {Consensus, SubnetID} from "../src/types/CommonTypes.sol";
 import {SubnetIDHelper} from "../src/util/SubnetIDHelper.sol";
 import {Test} from "forge-std/Test.sol";
 
-
 // Mock implementation of the ISubnetActorGetter interface for testing
 contract MockSubnetActor is ISubnetActorGetter {
     mapping(uint256 => BottomUpCheckpoint) internal checkpoints;

--- a/test/ValidatorRewarderFFI.t.sol
+++ b/test/ValidatorRewarderFFI.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.26;
 
-import {ValidatorRewarderTestBase} from "./ValidatorRewarder.t.sol";
+import {MockSubnetActor, ValidatorRewarderTestBase} from "./ValidatorRewarder.t.sol";
 import {console2} from "forge-std/console2.sol";
 
 // FFI reward calculation tests
@@ -38,6 +38,9 @@ contract ValidatorRewarderFFITest is ValidatorRewarderTestBase {
         // Process claims checkpoint by checkpoint
         for (uint256 i = 0; i < numCheckpoints; i++) {
             uint64 currentCheckpoint = uint64((i + 1) * checkpointPeriod);
+
+            // Update mock to return the correct number of blocks for this checkpoint
+            MockSubnetActor(SUBNET_ROUTE).setCheckpoint(currentCheckpoint, uint64(checkpointPeriod));
 
             // Calculate expected rewards for this checkpoint (in base units)
             uint256 checkpointTokens = (checkpointPeriod * 1 ether) / rewarder.BLOCKS_PER_TOKEN();


### PR DESCRIPTION
This pull request updates `ValidatorRewarder` contract and related scripts and tests. The changes focus on improving the accuracy of reward calculations.

In the earlier implementation we mistakenly assumed that every bottom-up checkpoint will always be 600 blocks (checkpoint period). This assumption is wrong. Bottom up checkpoints in IPC can be shorter than the checkpoint period. Sometimes when the max number of messages are added the checkpoint is sent immediately. 

These changes reads the actual number of blocks in the checkpoint and use that number for reward calculation. For instance, if any checkpoint contains only 300 blocks then the rewards claimed by the validator should be: 100 * validator's share. 

closes: https://github.com/recallnet/contracts/issues/100